### PR TITLE
style(wizard-controls): capitalise button first letter

### DIFF
--- a/src/WizardSteps/components/WizardControls/WizardControls.scss
+++ b/src/WizardSteps/components/WizardControls/WizardControls.scss
@@ -1,8 +1,16 @@
 @import 'src/styles';
 
+@mixin capitalize-first-letter {
+  text-transform: lowercase;
+
+  &::first-letter {
+    text-transform: uppercase;
+  }
+}
+
 .wizard-controls {
   .btn {
-    text-transform: capitalize;
+    @include capitalize-first-letter;
   }
 
   .btn-next,
@@ -11,6 +19,10 @@
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
+
+    span {
+      @include capitalize-first-letter;
+    }
   }
 
   .btn-next {

--- a/src/WizardSteps/components/WizardControls/WizardControls.test.tsx
+++ b/src/WizardSteps/components/WizardControls/WizardControls.test.tsx
@@ -39,11 +39,15 @@ describe('Component: WizardControls', () => {
   });
 
   it('Should render correctly', () => {
-    render(<WizardControls />);
+    const { container } = render(<WizardControls />);
     expect(screen.getByText('Back')).toBeInTheDocument();
-    expect(screen.getByText('Back').parentElement).toHaveClass('col-6');
+    expect(container.querySelector('.btn-prev').parentElement).toHaveClass(
+      'col-6'
+    );
     expect(screen.getByText('Next')).toBeInTheDocument();
-    expect(screen.getByText('Next').parentElement).toHaveClass('col-6');
+    expect(container.querySelector('.btn-next').parentElement).toHaveClass(
+      'col-6'
+    );
   });
 
   it('should render active controls when navigation context has active controls', () => {
@@ -77,7 +81,7 @@ describe('Component: WizardControls', () => {
   });
 
   it('Should render single navigation control', () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <WizardControls
         controls={[
           {
@@ -87,7 +91,9 @@ describe('Component: WizardControls', () => {
         ]}
       />
     );
-    expect(screen.getByText('forward').parentElement).toHaveClass('col-12');
+    expect(container.querySelector('.btn-next').parentElement).toHaveClass(
+      'col-12'
+    );
     rerender(
       <WizardControls
         controls={[
@@ -98,7 +104,9 @@ describe('Component: WizardControls', () => {
         ]}
       />
     );
-    expect(screen.getByText('backward').parentElement).toHaveClass('col-12');
+    expect(container.querySelector('.btn-prev').parentElement).toHaveClass(
+      'col-12'
+    );
   });
 
   it('Should navigate to previous step when prev button is clicked', async () => {

--- a/src/WizardSteps/components/WizardControls/WizardControls.tsx
+++ b/src/WizardSteps/components/WizardControls/WizardControls.tsx
@@ -124,7 +124,7 @@ const WizardControls: React.FC<WizardControlsProps> = ({
                     }
                   }}
                 >
-                  {label}
+                  <span>{label}</span>
                 </button>
               </div>
             );


### PR DESCRIPTION
create a `span` wrapper around button text to isolate the text from `pseudo element selector` interference