### PR TITLE
feat: add strict mode support

### DIFF
--- a/src/WizardSteps/WizardSteps.tsx
+++ b/src/WizardSteps/WizardSteps.tsx
@@ -41,6 +41,12 @@ export type WizardStepsProps = {
    * react router for navigations
    * */
   steps: Array<WizardStepConfig>;
+  /**
+   * Strict navigations guard toggle. If configure to true, user can only navigate
+   * to immediate next or previous step; when configure to false, user can navigate to any
+   * steps at any time. Default to true.
+   */
+  strict?: boolean;
 };
 
 export type WizardStepConfig = {
@@ -96,7 +102,7 @@ const WizardRoutes: React.FC<Pick<WizardStepsProps, 'steps'>> = ({ steps }) => {
 };
 
 const WizardSteps: React.FC<WizardStepsProps> = (props) => {
-  const { navigationDescription, steps: sourceSteps } = props;
+  const { navigationDescription, steps: sourceSteps, strict = true } = props;
   const { pathname } = useLocation();
   const match = useRouteMatch();
 
@@ -145,7 +151,7 @@ const WizardSteps: React.FC<WizardStepsProps> = (props) => {
   );
 
   return (
-    <NavigationProvider routes={routes}>
+    <NavigationProvider routes={routes} strict={strict}>
       <div className="row no-gutters wizard-steps">
         <div className="col-12 col-md-auto">
           <WizardNavigations

--- a/src/WizardSteps/components/WizardNavigations/WizardNavigations.tsx
+++ b/src/WizardSteps/components/WizardNavigations/WizardNavigations.tsx
@@ -111,7 +111,7 @@ const WizardNavigations: React.FC<WizardNavigationsProps> = ({
                         isValidStep().then((isValid) => {
                           if (isValid !== false) {
                             setToggle(false);
-                            nextStep();
+                            nextStep(props.path);
                           }
                         });
                       } else {

--- a/src/contexts/navigationContext.test.tsx
+++ b/src/contexts/navigationContext.test.tsx
@@ -96,10 +96,11 @@ describe('Context: NavigationContext', () => {
   function renderDummyComponent(
     props?: DummyComponentProps,
     history?: History,
-    routes: Array<string> = DEFAULT_ROUTES
+    routes: Array<string> = DEFAULT_ROUTES,
+    strict?: boolean
   ): RenderResult {
     return render(
-      <NavigationProvider routes={routes}>
+      <NavigationProvider routes={routes} strict={strict}>
         <DummyComponent {...props} />
       </NavigationProvider>,
       {
@@ -195,9 +196,14 @@ describe('Context: NavigationContext', () => {
       assertIsNavigableStep(true);
     });
 
-    it('Should return false when step provided is two or more steps ahead of current step', () => {
+    it('Should return false when step provided is two or more steps ahead of current step in strict mode', () => {
       renderDummyComponent({ mockStep: 2 });
       assertIsNavigableStep(false);
+    });
+
+    it('Should return true when step provided is two or more steps ahead of current step in non strict mode', () => {
+      renderDummyComponent({ mockStep: 2 }, undefined, undefined, false);
+      assertIsNavigableStep(true);
     });
 
     it('Should return true when step provided is any of the previous steps', () => {

--- a/src/contexts/navigationContext.tsx
+++ b/src/contexts/navigationContext.tsx
@@ -30,9 +30,10 @@ export interface NavigationInterface {
    */
   isValidStep: () => Promise<boolean>;
   /**
-   * Verify if the step provided is the immediate next step or any of the
-   * previous step and the wizard has not complete. A step is considered
-   * navigable if it satisfy any of the conditions mentioned above.
+   * When `strict` mode is enabled, this will verify if the step provided
+   * is the immediate next step or any of the previous step and the wizard
+   * has not complete. A step is considered navigable if it satisfy any of
+   * the conditions mentioned above.
    */
   isNavigableStep: (step: number) => boolean;
   /**
@@ -65,8 +66,16 @@ export interface NavigationInterface {
 }
 
 export type NavigationProviderProps = {
-  /** The list of routes path to be managed. */
+  /**
+   * The list of routes path to be managed.
+   * */
   routes: Array<string>;
+  /**
+   * Strict navigations guard toggle. If configure to `true`, user can only navigate
+   * to immediate next or previous step; when configure to `false`, user can navigate to any
+   * steps at any time. *Default* to `true`.
+   */
+  strict?: boolean;
 };
 
 const NavigationContext = React.createContext<NavigationInterface | undefined>(
@@ -76,6 +85,7 @@ const NavigationContext = React.createContext<NavigationInterface | undefined>(
 const NavigationProvider: React.FC<NavigationProviderProps> = ({
   children,
   routes,
+  strict = true,
 }) => {
   const history = useHistory();
   const [activeControls, setActiveControls] = React.useState<
@@ -90,8 +100,8 @@ const NavigationProvider: React.FC<NavigationProviderProps> = ({
   const completeWizard = React.useCallback(() => setWizardCompleted(true), []);
 
   const isNavigableStep = React.useCallback(
-    (step: number) => step <= activeStep + 1 && !isWizardCompleted,
-    [activeStep, isWizardCompleted]
+    (step: number) => (!strict || step <= activeStep + 1) && !isWizardCompleted,
+    [activeStep, isWizardCompleted, strict]
   );
 
   const isValidStep = React.useCallback(async () => {

--- a/src/stories/WizardSteps.stories.tsx
+++ b/src/stories/WizardSteps.stories.tsx
@@ -149,6 +149,7 @@ Default.args = {
       },
     },
   ],
+  strict: true,
 };
 
 export const WithSecondaryContent: Story<WizardStepsProps> = Template.bind({});


### PR DESCRIPTION
add strict mode support to enable strict navigational controls. 

when strict mode is turned on, user would only be able to navigate to immediate next step, this is useful when every subsequent step relies on the previous step to be completed.

when strict mode is turned off, user would be able to access any steps at any time, developer would be responsible for handling any pre-conditions of the steps

strict mode is **turned on** by default