### PR TITLE
refactor: decouple navigation provider

### DIFF
--- a/scripts/indexer.js
+++ b/scripts/indexer.js
@@ -9,6 +9,7 @@ const components = fs
     (name) =>
       fs.lstatSync(path.resolve(source, name)).isDirectory() &&
       !name.startsWith('__') &&
+      !name.startsWith('@types') &&
       !name.startsWith('assets') &&
       !name.startsWith('contexts') &&
       !name.startsWith('stories') &&

--- a/src/@types/jest.d.ts
+++ b/src/@types/jest.d.ts
@@ -1,0 +1,1 @@
+declare var defaultNavigationInterface: import('../contexts/navigationContext').NavigationInterface;

--- a/src/Wizard/Wizard.tsx
+++ b/src/Wizard/Wizard.tsx
@@ -1,6 +1,7 @@
 import { Modal } from '@sebgroup/react-components';
 import classnames from 'classnames';
 import React from 'react';
+import { NavigationProvider } from '../contexts/navigationContext';
 import './Wizard.scss';
 
 export type WizardProps = JSX.IntrinsicElements['div'] & {
@@ -28,7 +29,7 @@ const Wizard = React.forwardRef(
           ref={ref}
           className={classnames('wizard', props.className)}
         >
-          {children}
+          <NavigationProvider>{children}</NavigationProvider>
         </div>
       </Modal>
     );

--- a/src/Wizard/Wizard.tsx
+++ b/src/Wizard/Wizard.tsx
@@ -5,6 +5,12 @@ import { NavigationProvider } from '../contexts/navigationContext';
 import './Wizard.scss';
 
 export type WizardProps = JSX.IntrinsicElements['div'] & {
+  /**
+   * Strict navigations guard toggle. If configure to true, user can only navigate
+   * to immediate next or previous step; when configure to false, user can navigate to any
+   * steps at any time. Default to true.
+   */
+  strict?: boolean;
   /** Wizard toggle. */
   toggle: boolean;
   /** Event triggered when Wizard is dimissed */
@@ -13,7 +19,7 @@ export type WizardProps = JSX.IntrinsicElements['div'] & {
 
 const Wizard = React.forwardRef(
   (
-    { children, toggle, onDismissed, ...props }: WizardProps,
+    { children, strict, toggle, onDismissed, ...props }: WizardProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
     return (
@@ -29,7 +35,7 @@ const Wizard = React.forwardRef(
           ref={ref}
           className={classnames('wizard', props.className)}
         >
-          <NavigationProvider>{children}</NavigationProvider>
+          <NavigationProvider strict={strict}>{children}</NavigationProvider>
         </div>
       </Modal>
     );

--- a/src/WizardSteps/WizardSteps.test.tsx
+++ b/src/WizardSteps/WizardSteps.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { match, MemoryRouter, useRouteMatch } from 'react-router-dom';
+import { NavigationProvider } from '../contexts/navigationContext';
 import WizardSteps, { WizardStepConfig, WizardStepsProps } from './WizardSteps';
 
 jest.mock('react-router-dom', () => ({
@@ -50,7 +51,9 @@ describe('Component: WizardSteps', () => {
   function renderWithRouter(route: string = '/') {
     return render(
       <MemoryRouter initialEntries={[route]}>
-        <WizardSteps {...wizardStepsProps} />
+        <NavigationProvider>
+          <WizardSteps {...wizardStepsProps} />
+        </NavigationProvider>
       </MemoryRouter>
     );
   }

--- a/src/WizardSteps/WizardSteps.tsx
+++ b/src/WizardSteps/WizardSteps.tsx
@@ -39,9 +39,8 @@ export type WizardStepsProps = {
    * */
   steps: Array<WizardStepConfig>;
   /**
-   * Strict navigations guard toggle. If configure to true, user can only navigate
-   * to immediate next or previous step; when configure to false, user can navigate to any
-   * steps at any time. Default to true.
+   * @deprecated use `Wizard` component `strict` props instead
+   * @see {@link Wizard.strict}
    */
   strict?: boolean;
 };

--- a/src/WizardSteps/WizardSteps.tsx
+++ b/src/WizardSteps/WizardSteps.tsx
@@ -6,10 +6,7 @@ import {
   useLocation,
   useRouteMatch,
 } from 'react-router-dom';
-import {
-  NavigationProvider,
-  useNavigationContext,
-} from '../contexts/navigationContext';
+import { useNavigationContext } from '../contexts/navigationContext';
 import { WizardNavigationData } from './components/WizardNavigation';
 import WizardNavigations from './components/WizardNavigations';
 import WizardStep, { WizardStepData } from './components/WizardStep';
@@ -106,6 +103,7 @@ const WizardRoutes: React.FC<Pick<WizardStepsProps, 'steps'>> = ({ steps }) => {
 const WizardSteps: React.FC<WizardStepsProps> = (props) => {
   const { navigationDescription, steps: sourceSteps, strict = true } = props;
   const { pathname } = useLocation();
+  const { setRoutes, setStrict } = useNavigationContext();
   const match = useRouteMatch();
 
   const isNestedRoute = React.useCallback((route: string) => {
@@ -153,23 +151,29 @@ const WizardSteps: React.FC<WizardStepsProps> = (props) => {
     [parentPath, sourceSteps]
   );
 
+  React.useEffect(() => {
+    setRoutes(routes);
+  }, [routes, setRoutes]);
+
+  React.useEffect(() => {
+    setStrict(strict);
+  }, [strict, setStrict]);
+
   return (
-    <NavigationProvider routes={routes} strict={strict}>
-      <div className="row no-gutters wizard-steps">
-        <div className="col-12 col-md-auto">
-          <WizardNavigations
-            navigationDescription={navigationDescription}
-            navigations={navigations}
-          />
-        </div>
-        <div className="col-12 col-md bg-white wizard-main-container">
-          <Switch>
-            <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
-            <WizardRoutes steps={steps} />
-          </Switch>
-        </div>
+    <div className="row no-gutters wizard-steps">
+      <div className="col-12 col-md-auto">
+        <WizardNavigations
+          navigationDescription={navigationDescription}
+          navigations={navigations}
+        />
       </div>
-    </NavigationProvider>
+      <div className="col-12 col-md bg-white wizard-main-container">
+        <Switch>
+          <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
+          <WizardRoutes steps={steps} />
+        </Switch>
+      </div>
+    </div>
   );
 };
 

--- a/src/WizardSteps/components/WizardControls/WizardControls.test.tsx
+++ b/src/WizardSteps/components/WizardControls/WizardControls.test.tsx
@@ -6,27 +6,12 @@ import {
 } from '../../../contexts/navigationContext';
 import WizardControls, { WizardControl } from './WizardControls';
 
-jest.mock('../../../contexts/navigationContext', () => ({
-  useNavigationContext: jest.fn(),
-}));
+jest.mock('../../../contexts/navigationContext');
 
+const { defaultNavigationInterface } = global;
 const mockedUseNavigationContext = useNavigationContext as jest.Mock<NavigationInterface>;
 
 describe('Component: WizardControls', () => {
-  const defaultNavigationContext: NavigationInterface = {
-    activeControls: undefined,
-    activeStep: 0,
-    activeState: undefined,
-    isWizardCompleted: false,
-    completeWizard: jest.fn(),
-    isNavigableStep: jest.fn(),
-    isValidStep: jest.fn(),
-    nextStep: jest.fn(),
-    previousStep: jest.fn(),
-    setActiveControls: jest.fn(),
-    setActiveState: jest.fn(),
-    setActiveStep: jest.fn(),
-  };
   let mockNextStep: jest.Mock;
   let mockPreviousStep: jest.Mock;
 
@@ -34,7 +19,7 @@ describe('Component: WizardControls', () => {
     mockNextStep = jest.fn();
     mockPreviousStep = jest.fn();
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       nextStep: mockNextStep,
       previousStep: mockPreviousStep,
     }));
@@ -43,18 +28,18 @@ describe('Component: WizardControls', () => {
   it('Should render correctly', () => {
     const { container } = render(<WizardControls />);
     expect(screen.getByText('Back')).toBeInTheDocument();
-    expect(container.querySelector('.btn-prev').parentElement).toHaveClass(
+    expect(container.querySelector('.btn-prev')?.parentElement).toHaveClass(
       'col-6'
     );
     expect(screen.getByText('Next')).toBeInTheDocument();
-    expect(container.querySelector('.btn-next').parentElement).toHaveClass(
+    expect(container.querySelector('.btn-next')?.parentElement).toHaveClass(
       'col-6'
     );
   });
 
   it('should render active controls when navigation context has active controls', () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       activeControls: [{ type: 'cancel', label: 'custom' }],
     }));
     render(<WizardControls />);
@@ -93,7 +78,7 @@ describe('Component: WizardControls', () => {
         ]}
       />
     );
-    expect(container.querySelector('.btn-next').parentElement).toHaveClass(
+    expect(container.querySelector('.btn-next')?.parentElement).toHaveClass(
       'col-12'
     );
     rerender(
@@ -106,7 +91,7 @@ describe('Component: WizardControls', () => {
         ]}
       />
     );
-    expect(container.querySelector('.btn-prev').parentElement).toHaveClass(
+    expect(container.querySelector('.btn-prev')?.parentElement).toHaveClass(
       'col-12'
     );
   });

--- a/src/WizardSteps/components/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/WizardSteps/components/WizardNavigation/WizardNavigation.test.tsx
@@ -12,27 +12,12 @@ import {
 } from '../../../contexts/navigationContext';
 import WizardNavigation, { WizardNavigationProps } from './WizardNavigation';
 
-jest.mock('../../../contexts/navigationContext', () => ({
-  useNavigationContext: jest.fn(),
-}));
+jest.mock('../../../contexts/navigationContext');
 
+const { defaultNavigationInterface } = global;
 const mockedUseNavigationContext = useNavigationContext as jest.Mock<NavigationInterface>;
 
 describe('Component: WizardNavigation', () => {
-  const defaultNavigationContext: NavigationInterface = {
-    activeControls: undefined,
-    activeStep: 0,
-    activeState: undefined,
-    isWizardCompleted: false,
-    completeWizard: jest.fn(),
-    isNavigableStep: jest.fn(),
-    isValidStep: jest.fn(),
-    nextStep: jest.fn(),
-    previousStep: jest.fn(),
-    setActiveControls: jest.fn(),
-    setActiveState: jest.fn(),
-    setActiveStep: jest.fn(),
-  };
   const wizardNavigationProps: WizardNavigationProps = {
     label: 'Step 1',
     path: '/step1',
@@ -51,7 +36,7 @@ describe('Component: WizardNavigation', () => {
 
   beforeEach(() => {
     mockedUseNavigationContext.mockImplementation(
-      () => defaultNavigationContext
+      () => defaultNavigationInterface
     );
   });
 
@@ -69,7 +54,7 @@ describe('Component: WizardNavigation', () => {
 
   it('Should render completed state', () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       activeStep: 1,
     }));
     const { container } = renderWithRouter();
@@ -87,7 +72,7 @@ describe('Component: WizardNavigation', () => {
 
   it('Should render invalid state', () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       isNavigableStep: jest.fn().mockReturnValueOnce(false),
     }));
     const { container } = renderWithRouter();
@@ -126,7 +111,7 @@ describe('Component: WizardNavigation', () => {
 
   it('Should render navigation context active state', () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       activeState: 'danger',
     }));
     const { container } = renderWithRouter();

--- a/src/WizardSteps/components/WizardNavigations/WizardNavigations.test.tsx
+++ b/src/WizardSteps/components/WizardNavigations/WizardNavigations.test.tsx
@@ -17,27 +17,12 @@ import WizardNavigations, {
   WizardNavigationsProps,
 } from './WizardNavigations';
 
-jest.mock('../../../contexts/navigationContext', () => ({
-  useNavigationContext: jest.fn(),
-}));
+jest.mock('../../../contexts/navigationContext');
 
+const { defaultNavigationInterface } = global;
 const mockedUseNavigationContext = useNavigationContext as jest.Mock<NavigationInterface>;
 
 describe('Component: WizardNavigations', () => {
-  const defaultNavigationContext: NavigationInterface = {
-    activeControls: undefined,
-    activeStep: 0,
-    activeState: undefined,
-    isWizardCompleted: false,
-    completeWizard: jest.fn(),
-    isNavigableStep: jest.fn(),
-    isValidStep: jest.fn(),
-    nextStep: jest.fn(),
-    previousStep: jest.fn(),
-    setActiveControls: jest.fn(),
-    setActiveState: jest.fn(),
-    setActiveStep: jest.fn(),
-  };
   const wizardNavigationsProps: WizardNavigationsProps = {
     navigationDescription: 'Description',
     navigations: [
@@ -93,7 +78,7 @@ describe('Component: WizardNavigations', () => {
 
   beforeEach(() => {
     mockedUseNavigationContext.mockImplementation(
-      () => defaultNavigationContext
+      () => defaultNavigationInterface
     );
   });
 
@@ -138,35 +123,35 @@ describe('Component: WizardNavigations', () => {
 
   it('Should navigate to selected step when navigation link clicked is navigable and step handler is valid', async () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       isNavigableStep: jest.fn().mockReturnValueOnce(true),
       isValidStep: jest.fn().mockResolvedValueOnce(true),
     }));
     renderWithRouter();
-    expect(defaultNavigationContext.nextStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.nextStep).not.toHaveBeenCalled();
     await waitFor(() => {
       navigateTo(1);
     });
-    expect(defaultNavigationContext.nextStep).toHaveBeenCalledTimes(1);
+    expect(defaultNavigationInterface.nextStep).toHaveBeenCalledTimes(1);
   });
 
   it('Should retain at current step when navigation link clicked is navigable but step handler is invalid', async () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       isNavigableStep: jest.fn().mockReturnValueOnce(true),
       isValidStep: jest.fn().mockResolvedValueOnce(false),
     }));
     renderWithRouter();
-    expect(defaultNavigationContext.nextStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.nextStep).not.toHaveBeenCalled();
     await waitFor(() => {
       navigateTo(1);
     });
-    expect(defaultNavigationContext.nextStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.nextStep).not.toHaveBeenCalled();
   });
 
   it('Should retain at current step when navigation link clicked is navigable but step is disabled', async () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       isNavigableStep: jest.fn().mockReturnValueOnce(true),
     }));
     renderWithRouter({
@@ -182,18 +167,18 @@ describe('Component: WizardNavigations', () => {
         },
       ],
     });
-    expect(defaultNavigationContext.isValidStep).not.toHaveBeenCalled();
-    expect(defaultNavigationContext.nextStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.isValidStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.nextStep).not.toHaveBeenCalled();
     await waitFor(() => {
       fireEvent.click(screen.getByRole('link', { name: 'Disabled Step' }));
     });
-    expect(defaultNavigationContext.nextStep).not.toHaveBeenCalled();
-    expect(defaultNavigationContext.isValidStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.nextStep).not.toHaveBeenCalled();
+    expect(defaultNavigationInterface.isValidStep).not.toHaveBeenCalled();
   });
 
   it('Should retain navigation list expansion when navigation link clicked is not navigable', async () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       isNavigableStep: jest.fn().mockReturnValueOnce(false),
     }));
     const { container } = renderWithRouter();
@@ -207,7 +192,7 @@ describe('Component: WizardNavigations', () => {
 
   it('Should collapse navigation list when navigate to previous step', async () => {
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       activeStep: 2,
       isNavigableStep: jest.fn().mockReturnValueOnce(true),
     }));

--- a/src/WizardSteps/components/WizardStep/WizardStep.test.tsx
+++ b/src/WizardSteps/components/WizardStep/WizardStep.test.tsx
@@ -6,10 +6,9 @@ import {
 } from '../../../contexts/navigationContext';
 import WizardStep, { WizardStepProps } from './WizardStep';
 
-jest.mock('../../../contexts/navigationContext', () => ({
-  useNavigationContext: jest.fn(),
-}));
+jest.mock('../../../contexts/navigationContext');
 
+const { defaultNavigationInterface } = global;
 const mockedUseNavigationContext = useNavigationContext as jest.Mock<NavigationInterface>;
 
 describe('Component: WizardStep', () => {
@@ -18,20 +17,6 @@ describe('Component: WizardStep', () => {
     heading: 'Step heading',
     pageHeading: 'Step page heading',
     state: 'info',
-  };
-  const defaultNavigationContext: NavigationInterface = {
-    activeControls: undefined,
-    activeState: undefined,
-    activeStep: 0,
-    isWizardCompleted: false,
-    completeWizard: jest.fn(),
-    isNavigableStep: jest.fn(),
-    isValidStep: jest.fn(),
-    nextStep: jest.fn(),
-    previousStep: jest.fn(),
-    setActiveControls: jest.fn(),
-    setActiveState: jest.fn(),
-    setActiveStep: jest.fn(),
   };
   let mockSetActiveControls: jest.Mock;
   let mockSetActiveState: jest.Mock;
@@ -42,7 +27,7 @@ describe('Component: WizardStep', () => {
     mockSetActiveState = jest.fn();
     mockSetActiveStep = jest.fn();
     mockedUseNavigationContext.mockImplementation(() => ({
-      ...defaultNavigationContext,
+      ...defaultNavigationInterface,
       setActiveControls: mockSetActiveControls,
       setActiveState: mockSetActiveState,
       setActiveStep: mockSetActiveStep,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -5,3 +5,22 @@
 import '@testing-library/jest-dom';
 
 global.scrollTo = jest.fn();
+
+global.defaultNavigationInterface = {
+  activeControls: undefined,
+  activeState: undefined,
+  activeStep: 0,
+  isWizardCompleted: false,
+  isStrict: false,
+  routes: [],
+  completeWizard: jest.fn(),
+  isNavigableStep: jest.fn(),
+  isValidStep: jest.fn(),
+  nextStep: jest.fn(),
+  previousStep: jest.fn(),
+  setActiveControls: jest.fn(),
+  setActiveState: jest.fn(),
+  setActiveStep: jest.fn(),
+  setRoutes: jest.fn(),
+  setStrict: jest.fn(),
+};

--- a/src/stories/WizardSteps.stories.tsx
+++ b/src/stories/WizardSteps.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { useNavigationContext } from '../contexts/navigationContext';
+import {
+  NavigationProvider,
+  useNavigationContext,
+} from '../contexts/navigationContext';
 import WizardSteps, { WizardStepsProps } from '../WizardSteps';
 import * as WizardControlsStories from './WizardControls.stories';
 
@@ -10,7 +13,11 @@ export default {
   component: WizardSteps,
   argTypes: {},
   decorators: [
-    (Story) => <MemoryRouter initialEntries={['/']}>{Story()}</MemoryRouter>,
+    (Story) => (
+      <MemoryRouter initialEntries={['/']}>
+        <NavigationProvider routes={['/']}>{Story()}</NavigationProvider>
+      </MemoryRouter>
+    ),
   ],
 } as Meta;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
     "node_modules",
     "dist",
     "**/.*",
-    "src/stories/**",
-    "src/**/*.test.*"
+    "src/stories/**"
   ]
 }


### PR DESCRIPTION
- move navigation provider from child components `WizardSteps` to the highest level component `Wizard` to ensure navigation context is available to all `Wizard` child components