### PR TITLE
fix: strict mode not working anymore

### DIFF
--- a/src/WizardSteps/WizardSteps.tsx
+++ b/src/WizardSteps/WizardSteps.tsx
@@ -38,11 +38,6 @@ export type WizardStepsProps = {
    * react router for navigations
    * */
   steps: Array<WizardStepConfig>;
-  /**
-   * @deprecated use `Wizard` component `strict` props instead
-   * @see {@link Wizard.strict}
-   */
-  strict?: boolean;
 };
 
 export type WizardStepConfig = {
@@ -100,9 +95,9 @@ const WizardRoutes: React.FC<Pick<WizardStepsProps, 'steps'>> = ({ steps }) => {
 };
 
 const WizardSteps: React.FC<WizardStepsProps> = (props) => {
-  const { navigationDescription, steps: sourceSteps, strict = true } = props;
+  const { navigationDescription, steps: sourceSteps } = props;
   const { pathname } = useLocation();
-  const { setRoutes, setStrict } = useNavigationContext();
+  const { setRoutes } = useNavigationContext();
   const match = useRouteMatch();
 
   const isNestedRoute = React.useCallback((route: string) => {
@@ -153,10 +148,6 @@ const WizardSteps: React.FC<WizardStepsProps> = (props) => {
   React.useEffect(() => {
     setRoutes(routes);
   }, [routes, setRoutes]);
-
-  React.useEffect(() => {
-    setStrict(strict);
-  }, [strict, setStrict]);
 
   return (
     <div className="row no-gutters wizard-steps">

--- a/src/contexts/navigationContext.test.tsx
+++ b/src/contexts/navigationContext.test.tsx
@@ -21,7 +21,7 @@ type DummyComponentProps = {
 };
 
 function DummyComponent(props: DummyComponentProps) {
-  const { mockControls, mockState, mockStep, nextPath, prevPath } = props;
+  const { mockControls, mockState, mockStep = 1, nextPath, prevPath } = props;
   const {
     activeControls = [],
     activeState,
@@ -100,7 +100,8 @@ describe('Context: NavigationContext', () => {
     strict?: boolean
   ): RenderResult {
     return render(
-      <NavigationProvider routes={routes} strict={strict}>
+      <NavigationProvider strict={strict}>
+        <RouteTracker routes={routes} />
         <DummyComponent {...props} />
       </NavigationProvider>,
       {
@@ -109,6 +110,16 @@ describe('Context: NavigationContext', () => {
           : ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
       }
     );
+  }
+
+  function RouteTracker({ routes }: { routes: Array<string> }) {
+    const { setRoutes } = useNavigationContext();
+
+    React.useEffect(() => {
+      setRoutes(routes);
+    }, [routes, setRoutes]);
+
+    return <></>;
   }
 
   function completeWizard() {

--- a/src/contexts/navigationContext.tsx
+++ b/src/contexts/navigationContext.tsx
@@ -19,7 +19,7 @@ export interface NavigationInterface {
   /**
    * Strict navigations guard toggle. If configure to `true`, user can only navigate
    * to immediate next or previous step; when configure to `false`, user can navigate to any
-   * steps at any time. *Default* to `true`.
+   * steps at any time.
    */
   isStrict: boolean;
   /**
@@ -77,17 +77,9 @@ export interface NavigationInterface {
    * Configure the routes path to be managed.
    */
   setRoutes: React.Dispatch<React.SetStateAction<Array<string>>>;
-  /**
-   * Configure the navigation mode.
-   */
-  setStrict: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export type NavigationProviderProps = {
-  /**
-   * The list of routes path to be managed.
-   * */
-  routes?: Array<string>;
   /**
    * Strict navigations guard toggle. If configure to `true`, user can only navigate
    * to immediate next or previous step; when configure to `false`, user can navigate to any
@@ -102,8 +94,7 @@ const NavigationContext = React.createContext<NavigationInterface | undefined>(
 
 const NavigationProvider: React.FC<NavigationProviderProps> = ({
   children,
-  routes: initialRoutes = [],
-  strict: initialStrict = true,
+  strict = true,
 }) => {
   const history = useHistory();
   const [activeControls, setActiveControls] = React.useState<
@@ -111,18 +102,16 @@ const NavigationProvider: React.FC<NavigationProviderProps> = ({
   >();
   const [activeState, setActiveState] = React.useState<WizardStepState>();
   const [activeStep, setActiveStep] = React.useState<number>(0);
-  const [isStrict, setStrict] = React.useState<boolean>(initialStrict);
   const [isWizardCompleted, setWizardCompleted] = React.useState<boolean>(
     false
   );
-  const [routes, setRoutes] = React.useState<Array<string>>(initialRoutes);
+  const [routes, setRoutes] = React.useState<Array<string>>([]);
 
   const completeWizard = React.useCallback(() => setWizardCompleted(true), []);
 
   const isNavigableStep = React.useCallback(
-    (step: number) =>
-      (!isStrict || step <= activeStep + 1) && !isWizardCompleted,
-    [activeStep, isWizardCompleted, isStrict]
+    (step: number) => (!strict || step <= activeStep + 1) && !isWizardCompleted,
+    [activeStep, isWizardCompleted, strict]
   );
 
   const isValidStep = React.useCallback(async () => {
@@ -167,7 +156,7 @@ const NavigationProvider: React.FC<NavigationProviderProps> = ({
         activeControls,
         activeState,
         activeStep,
-        isStrict,
+        isStrict: strict,
         isWizardCompleted,
         routes,
         completeWizard,
@@ -179,7 +168,6 @@ const NavigationProvider: React.FC<NavigationProviderProps> = ({
         setActiveState,
         setActiveStep,
         setRoutes,
-        setStrict,
       }}
     >
       {children}

--- a/src/stories/Wizard.stories.tsx
+++ b/src/stories/Wizard.stories.tsx
@@ -21,7 +21,12 @@ export default {
 } as Meta;
 
 const Template: Story<WizardProps> = ({ ref, ...args }) => {
+  const [strict, setStrict] = React.useState<boolean>(args.strict);
   const [toggle, setToggle] = React.useState<boolean>(args.toggle);
+
+  React.useEffect(() => {
+    setStrict(args.strict);
+  }, [args.strict]);
 
   React.useEffect(() => {
     setToggle(args.toggle);
@@ -34,7 +39,7 @@ const Template: Story<WizardProps> = ({ ref, ...args }) => {
           Show Wizard
         </button>
       </div>
-      <Wizard {...args} toggle={toggle}>
+      <Wizard {...args} strict={strict} toggle={toggle}>
         <WizardHeader
           heading="Wizard Title"
           actions={[
@@ -59,5 +64,6 @@ const Template: Story<WizardProps> = ({ ref, ...args }) => {
 export const Default: Story<WizardProps> = Template.bind({});
 Default.args = {
   toggle: false,
+  strict: true,
   onDismissed: action('dismissed'),
 };

--- a/src/stories/WizardControls.stories.tsx
+++ b/src/stories/WizardControls.stories.tsx
@@ -10,11 +10,7 @@ export default {
   title: 'components/WizardControls',
   component: WizardControls,
   argTypes: {},
-  decorators: [
-    (Story) => (
-      <NavigationProvider routes={['/']}>{Story()}</NavigationProvider>
-    ),
-  ],
+  decorators: [(Story) => <NavigationProvider>{Story()}</NavigationProvider>],
 } as Meta;
 
 const Template: Story<WizardControlsProps> = (args) => (

--- a/src/stories/WizardNavigation.stories.tsx
+++ b/src/stories/WizardNavigation.stories.tsx
@@ -21,7 +21,7 @@ export default {
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/']}>
-        <NavigationProvider routes={['/']}>
+        <NavigationProvider>
           <ul className="list-group list-group-ordered">{Story()}</ul>
         </NavigationProvider>
       </MemoryRouter>

--- a/src/stories/WizardNavigations.stories.tsx
+++ b/src/stories/WizardNavigations.stories.tsx
@@ -13,7 +13,7 @@ export default {
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/']}>
-        <NavigationProvider routes={['/']}>{Story()}</NavigationProvider>
+        <NavigationProvider>{Story()}</NavigationProvider>
       </MemoryRouter>
     ),
   ],

--- a/src/stories/WizardSteps.stories.tsx
+++ b/src/stories/WizardSteps.stories.tsx
@@ -15,21 +15,12 @@ export default {
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/']}>
-        <NavigationProvider routes={['/']}>{Story()}</NavigationProvider>
+        <NavigationProvider>{Story()}</NavigationProvider>
       </MemoryRouter>
     ),
   ],
 } as Meta;
 
-const Template: Story<WizardStepsProps> = (args) => {
-  const [strict, setStrict] = React.useState<boolean>(!!args.strict);
-
-  React.useEffect(() => {
-    setStrict(args.strict);
-  }, [args.strict]);
-
-  return <WizardSteps {...args} strict={strict} />;
-};
 const StepComponent: React.FC = () => {
   const { completeWizard, setActiveState } = useNavigationContext();
   return (
@@ -126,6 +117,7 @@ const StepComponent: React.FC = () => {
     </div>
   );
 };
+const Template: Story<WizardStepsProps> = (args) => <WizardSteps {...args} />;
 
 export const Default: Story<WizardStepsProps> = Template.bind({});
 Default.args = {
@@ -164,7 +156,6 @@ Default.args = {
       },
     },
   ],
-  strict: true,
 };
 
 export const WithSecondaryContent: Story<WizardStepsProps> = Template.bind({});


### PR DESCRIPTION
fix strict mode settings being overridden by a child component configuration by removing the said configuration from the child component, which in turn introduces a breaking changes. there's options to remove the overridden but it make much more sense just to introduce a version where the configuration is only at the top level component instead of multiple location