### PR TITLE
fix: revert the right padding of introductory navigation

### DIFF
--- a/src/WizardSteps/components/WizardNavigations/WizardNavigations.scss
+++ b/src/WizardSteps/components/WizardNavigations/WizardNavigations.scss
@@ -37,7 +37,7 @@
       }
 
       a {
-        padding-inline: 1rem;
+        padding-left: 1rem;
       }
     }
 


### PR DESCRIPTION
- this is to take into account the navigate state icon spacing